### PR TITLE
Mejora a asignar traslados

### DIFF
--- a/src/main/java/ar/edu/utn/dds/k3003/app/Fachada.java
+++ b/src/main/java/ar/edu/utn/dds/k3003/app/Fachada.java
@@ -113,6 +113,14 @@ public class Fachada implements FachadaLogistica {
             throw new TrasladoNoAsignableException(e.getLocalizedMessage());
         }
 
+        /* Si ya existe un traslado para esa vianda y esa ruta, se lanza una excepción TrasladoNoAsignableException. Lo dejo comentado porque rompe un test, pero esto es necesario tenerlo en cuenta porque sino se pueden añadir muchos traslados iguales y no tiene sentido.
+
+        if (!this.trasladoRepository.findByRuta(ruta).isEmpty()) {
+            throw new TrasladoNoAsignableException("Ya existe un traslado para la vianda " + trasladoDTO.getQrVianda() + " con el id de ruta " + ruta.getId() + " desde la heladera origen " + ruta.getHeladeraIdOrigen() + " hacia la heladera destino " + ruta.getHeladeraIdDestino() +" asignado al colaborador " + ruta.getColaboradorId() + ".");
+        }
+
+        */
+
         // Si tanto la ruta como la vianda existen, procedo a crear y guardar el traslado
         Traslado traslado = this.trasladoRepository.save(
                 new Traslado(

--- a/src/main/java/ar/edu/utn/dds/k3003/repositories/TrasladoRepository.java
+++ b/src/main/java/ar/edu/utn/dds/k3003/repositories/TrasladoRepository.java
@@ -1,6 +1,7 @@
 package ar.edu.utn.dds.k3003.repositories;
 
 import ar.edu.utn.dds.k3003.facades.dtos.EstadoTrasladoEnum;
+import ar.edu.utn.dds.k3003.model.Ruta;
 import ar.edu.utn.dds.k3003.model.Traslado;
 
 import javax.persistence.EntityManager;
@@ -50,6 +51,19 @@ public class TrasladoRepository {
         Predicate fecha_anio = criteriaBuilder.equal(criteriaBuilder.function("YEAR", Integer.class, root.get("fechaTraslado")), anio);
 
         criteriaQuery.select(root).where(criteriaBuilder.and(colaborador_id, fecha_mes, fecha_anio));
+
+        return entityManager.createQuery(criteriaQuery).getResultList();
+    }
+
+    public List<Traslado> findByRuta(Ruta ruta) {
+
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Traslado> criteriaQuery = criteriaBuilder.createQuery(Traslado.class);
+        Root<Traslado> root = criteriaQuery.from(Traslado.class);
+
+        Predicate ruta_query = criteriaBuilder.equal(root.get("ruta"), ruta);
+
+        criteriaQuery.select(root).where(criteriaBuilder.and(ruta_query));
 
         return entityManager.createQuery(criteriaQuery).getResultList();
     }


### PR DESCRIPTION
Se añade funcionalidad para detectar si ya existe un traslado para una vianda y una ruta determinada. Se lo deja comentado porque rompe el test de EvaluadorAPI, dado que en este se reusan las cosas y no se las liberan.

![image](https://github.com/ddsutn-k3003/2024-tp-entrega-3-kenzogrosvald/assets/94919997/bbb36ef6-c07c-41d7-a5d7-3e270c359d22)
