### PR TITLE
Unicidad de traslados

### DIFF
--- a/src/main/java/ar/edu/utn/dds/k3003/app/Fachada.java
+++ b/src/main/java/ar/edu/utn/dds/k3003/app/Fachada.java
@@ -113,13 +113,11 @@ public class Fachada implements FachadaLogistica {
             throw new TrasladoNoAsignableException(e.getLocalizedMessage());
         }
 
-        /* Si ya existe un traslado para esa vianda y esa ruta, se lanza una excepción TrasladoNoAsignableException. Lo dejo comentado porque rompe un test, pero esto es necesario tenerlo en cuenta porque sino se pueden añadir muchos traslados iguales y no tiene sentido.
+        // Si ya existe un traslado para esa vianda y esa ruta, se lanza una excepción TrasladoNoAsignableException. Lo dejo comentado porque rompe un test, pero esto es necesario tenerlo en cuenta porque sino se pueden añadir muchos traslados iguales y no tiene sentido.
 
         if (!this.trasladoRepository.findByRuta(ruta).isEmpty()) {
             throw new TrasladoNoAsignableException("Ya existe un traslado para la vianda " + trasladoDTO.getQrVianda() + " con el id de ruta " + ruta.getId() + " desde la heladera origen " + ruta.getHeladeraIdOrigen() + " hacia la heladera destino " + ruta.getHeladeraIdDestino() +" asignado al colaborador " + ruta.getColaboradorId() + ".");
         }
-
-        */
 
         // Si tanto la ruta como la vianda existen, procedo a crear y guardar el traslado
         Traslado traslado = this.trasladoRepository.save(


### PR DESCRIPTION
Se descomenta método que verifica la unicidad de los traslados en base a su ruta y vianda. 

Los tests por pipeline rompen porque en los tests evaluadores que se ejecutan saltan la excepción que justamente se está añadiendo con este método nuevo para verificar.

En principio, no debería ser posible asignar un traslado con una misma ruta y vianda más de una vez, y es lo que sucede en los tests evaluadores.

Será necesario corregir esto en los tests evaluadores y actualizar la dependencia en el `pom.xml` para que vuelvan a pasar los tests.
